### PR TITLE
Fix device trackers

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -70,8 +70,9 @@ person:
     id: 9171f88c29f143e9a2a2f5ea2890339d
     device_trackers:
       - device_tracker.petes_iphone_bt
+      - device_tracker.petes_iphone_gps
       - device_tracker.petes_iphone_wifi
-      - device_tracker.petes_keys
+      - device_tracker.tile_e4dd14420d344e34
   - name: Emma
     id: 6Y7i2MHyeedbkHT7o$sZ&bPOyk7f1guQ
     device_trackers:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -72,7 +72,7 @@ person:
       - device_tracker.petes_iphone_bt
       - device_tracker.petes_iphone_gps
       - device_tracker.petes_iphone_wifi
-      - device_tracker.tile_e4dd14420d344e34
+#      - device_tracker.tile_e4dd14420d344e34
   - name: Emma
     id: 6Y7i2MHyeedbkHT7o$sZ&bPOyk7f1guQ
     device_trackers:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -75,7 +75,8 @@ person:
   - name: Emma
     id: 6Y7i2MHyeedbkHT7o$sZ&bPOyk7f1guQ
     device_trackers:
-      - device_tracker.emmas_iphone
+      - device_tracker.emmas_iphone_bt
+      - device_tracker.emmas_iphone_wifi
 
 roku:
   - host: 192.168.0.123

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -69,7 +69,8 @@ person:
   - name: Pete
     id: 9171f88c29f143e9a2a2f5ea2890339d
     device_trackers:
-      - device_tracker.petes_iphone
+      - device_tracker.petes_iphone_bt
+      - device_tracker.petes_iphone_wifi
       - device_tracker.petes_keys
   - name: Emma
     id: 6Y7i2MHyeedbkHT7o$sZ&bPOyk7f1guQ


### PR DESCRIPTION
This is a remediation of device trackers, mainly.

Bluetooth, GPS and Wifi are broken out as separate trackers for general cleanliness reasons.

Also, i add my keys' device_tracker to the Person. Hopefully this way - if I take my phone outside, and it falls off the WiFi, the Person doesn't necessarily become AWAY.